### PR TITLE
Update README with local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# MY personal Website
+# Alain Tissier's Personal Website
 
+This repository contains the source code for my personal website built with [Jekyll](https://jekyllrb.com/). The site includes information about my background, projects and curriculum vitae.
+
+## Live Site
+
+The website is available at [https://alain-tissier.com](https://alain-tissier.com).
+
+## Running Locally
+
+To preview the site locally you need Ruby installed. Once Ruby is available you can install Jekyll and run the development server:
+
+```bash
+# Install Jekyll (and Bundler if you do not have it)
+gem install jekyll bundler
+
+# Start the server from the repository root
+jekyll serve
+```
+
+This will start a local server at `http://localhost:4000` where you can view changes as you edit the files.
+
+## License
+
+This repository does not currently include an explicit license file. Please contact the repository owner for reuse permissions.


### PR DESCRIPTION
## Summary
- expand README with a description of the site
- provide steps for running Jekyll locally and link to the website
- clarify that no license file is present

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687244206fd08328b85c8983da839be3